### PR TITLE
feat: add classroom management support

### DIFF
--- a/server/src/routes/classroom.ts
+++ b/server/src/routes/classroom.ts
@@ -1,0 +1,271 @@
+import { Router, Request, Response } from "express";
+import {
+  ClassroomSummary,
+  CreateClassroomInput,
+  Database,
+  DatabaseClassroom,
+  DatabaseUser,
+  UpdateClassroomInput,
+} from "../database";
+import { requireAuth, requireRole } from "../middleware";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type ClassroomShape = "ids" | "full";
+
+export function sanitizeStudentEmails(value: unknown): string[] | null {
+  if (value == null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const normalized = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : null))
+    .filter((entry): entry is string => Boolean(entry));
+
+  return Array.from(new Set(normalized));
+}
+
+export function isValidEmail(value: string): boolean {
+  return EMAIL_REGEX.test(value);
+}
+
+const summarizeClassroom = (classroom: ClassroomSummary) => ({
+  classroomId: classroom.classroomId,
+  className: classroom.className,
+  subject: classroom.subject,
+  teacher: classroom.teacher,
+});
+
+const formatClassroom = (classroom: DatabaseClassroom) => ({
+  classroomId: classroom.classroomId,
+  className: classroom.className,
+  subject: classroom.subject,
+  teacher: classroom.teacher,
+  students: Array.from(classroom.students).sort(),
+  assignments: Array.from(classroom.assignments).sort(),
+});
+
+const resolveShape = (
+  requested: string | undefined,
+  role: string
+): ClassroomShape | null => {
+  if (!requested) {
+    return role === "teacher" ? "full" : "ids";
+  }
+
+  if (requested === "ids" || requested === "full") {
+    return requested;
+  }
+
+  return null;
+};
+
+const ensureTeacherOwnership = (
+  classroom: DatabaseClassroom | null,
+  teacherEmail: string
+) => {
+  if (!classroom) {
+    return { status: 404, body: { error: "Classroom not found" } } as const;
+  }
+
+  if (classroom.teacher !== teacherEmail) {
+    return {
+      status: 403,
+      body: { error: "Insufficient permissions" },
+    } as const;
+  }
+
+  return null;
+};
+
+const ensureStudentMembership = (
+  classroom: DatabaseClassroom | null,
+  studentEmail: string
+) => {
+  if (!classroom) {
+    return { status: 404, body: { error: "Classroom not found" } } as const;
+  }
+
+  if (!classroom.students.has(studentEmail)) {
+    return {
+      status: 403,
+      body: { error: "Insufficient permissions" },
+    } as const;
+  }
+
+  return null;
+};
+
+const createClassroomRouter = (database: Database): Router => {
+  const router = Router();
+
+  router.use(requireAuth);
+
+  router.get("/", async (req: Request, res: Response) => {
+    const user = req.user as DatabaseUser;
+    const classroomId = req.query.classroomId as string | undefined;
+    const shape = resolveShape(req.query.shape as string | undefined, user.role);
+
+    if (!shape) {
+      return res.status(400).json({ error: "Invalid shape parameter" });
+    }
+
+    if (classroomId) {
+      const classroom = await database.getClassroomById(classroomId);
+
+      if (user.role === "teacher") {
+        const error = ensureTeacherOwnership(classroom, user.email);
+        if (error) {
+          return res.status(error.status).json(error.body);
+        }
+      } else {
+        const error = ensureStudentMembership(classroom, user.email);
+        if (error) {
+          return res.status(error.status).json(error.body);
+        }
+      }
+
+      return res.json({ classroom: formatClassroom(classroom!) });
+    }
+
+    if (user.role === "teacher") {
+      const summaries = await database.getClassroomSummariesByTeacher(
+        user.email
+      );
+
+      if (shape === "ids") {
+        return res.json({ classrooms: summaries.map((c) => c.classroomId) });
+      }
+
+      return res.json({
+        classrooms: summaries.map(summarizeClassroom),
+      });
+    }
+
+    const summaries = await database.getClassroomSummariesByStudent(
+      user.email
+    );
+
+    if (shape === "ids") {
+      return res.json({ classrooms: summaries.map((c) => c.classroomId) });
+    }
+
+    return res.json({ classrooms: summaries.map(summarizeClassroom) });
+  });
+
+  router.post(
+    "/create",
+    requireRole("teacher"),
+    async (req: Request, res: Response) => {
+      const user = req.user as DatabaseUser;
+      const { className, subject } = req.body as CreateClassroomInput;
+      const sanitized = sanitizeStudentEmails(req.body.students);
+
+      if (!className || typeof className !== "string") {
+        return res.status(400).json({ error: "className is required" });
+      }
+
+      if (!subject || typeof subject !== "string") {
+        return res.status(400).json({ error: "subject is required" });
+      }
+
+      if (sanitized === null) {
+        return res.status(400).json({ error: "students must be an array" });
+      }
+
+      const invalidEmail = sanitized.find((email) => !isValidEmail(email));
+      if (invalidEmail) {
+        return res.status(400).json({ error: "Invalid student email" });
+      }
+
+      const classroom = await database.createClassroom({
+        className,
+        subject,
+        students: sanitized,
+        teacher: user.email,
+      });
+
+      return res.status(201).json({ classroom: formatClassroom(classroom) });
+    }
+  );
+
+  router.patch(
+    "/update",
+    requireRole("teacher"),
+    async (req: Request, res: Response) => {
+      const user = req.user as DatabaseUser;
+      const { classroomId, className, subject } =
+        req.body as UpdateClassroomInput;
+
+      if (!classroomId || typeof classroomId !== "string") {
+        return res.status(400).json({ error: "classroomId is required" });
+      }
+
+      if (className !== undefined && typeof className !== "string") {
+        return res.status(400).json({ error: "className must be a string" });
+      }
+
+      if (subject !== undefined && typeof subject !== "string") {
+        return res.status(400).json({ error: "subject must be a string" });
+      }
+
+      if (className === undefined && subject === undefined) {
+        return res
+          .status(400)
+          .json({ error: "className or subject must be provided" });
+      }
+
+      const existing = await database.getClassroomById(classroomId);
+      const ownershipError = ensureTeacherOwnership(existing, user.email);
+      if (ownershipError) {
+        return res.status(ownershipError.status).json(ownershipError.body);
+      }
+
+      const updated = await database.updateClassroom({
+        classroomId,
+        className,
+        subject,
+      });
+
+      if (!updated) {
+        return res.status(404).json({ error: "Classroom not found" });
+      }
+
+      return res.json({ classroom: formatClassroom(updated) });
+    }
+  );
+
+  router.delete(
+    "/:classroomId",
+    requireRole("teacher"),
+    async (req: Request, res: Response) => {
+      const user = req.user as DatabaseUser;
+      const { classroomId } = req.params;
+
+      if (!classroomId) {
+        return res.status(400).json({ error: "classroomId is required" });
+      }
+
+      const classroom = await database.getClassroomById(classroomId);
+      const ownershipError = ensureTeacherOwnership(classroom, user.email);
+      if (ownershipError) {
+        return res.status(ownershipError.status).json(ownershipError.body);
+      }
+
+      const deleted = await database.deleteClassroom(classroomId);
+      if (!deleted) {
+        return res.status(404).json({ error: "Classroom not found" });
+      }
+
+      return res.status(204).send();
+    }
+  );
+
+  return router;
+};
+
+export default createClassroomRouter;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -10,6 +10,7 @@ import { configurePassport } from "./config/passport";
 import { requireAuth, requireRole } from "./middleware";
 import { initializeSocketHandlers } from "./socket/socketHandlers";
 import createAuthRouter from "./routes/auth";
+import createClassroomRouter from "./routes/classroom";
 import "./types/session";
 import { Database, DatabaseUser } from "./database";
 import { SessionData } from "express-session";
@@ -85,6 +86,10 @@ async function initializeApp() {
 
     // Mount auth routes with /auth prefix
     app.use("/auth", authRouter.router);
+
+    // Classroom routes
+    const classroomRouter = createClassroomRouter(database);
+    app.use("/classroom", classroomRouter);
 
     // Initialize Socket.IO handlers with database collections
     initializeSocketHandlers(io, database, openai);

--- a/server/tests/e2e/database.e2e.test.ts
+++ b/server/tests/e2e/database.e2e.test.ts
@@ -207,6 +207,42 @@ describeIfConnection("Database end-to-end with PostgreSQL", () => {
       await database.incrementBrainPoints("missing@example.com", 3)
     ).toBeNull();
     expect(await database.getUserByEmail("missing@example.com")).toBeNull();
+
+    const classroom = await database.createClassroom({
+      className: "Algebra I",
+      subject: "Mathematics",
+      students: [studentEmail],
+      teacher: teacherEmail,
+    });
+
+    expect(classroom.teacher).toBe(teacherEmail);
+    expect(classroom.students.has(studentEmail)).toBe(true);
+
+    const teacherSummaries = await database.getClassroomSummariesByTeacher(
+      teacherEmail
+    );
+    expect(teacherSummaries.map((summary) => summary.classroomId)).toContain(
+      classroom.classroomId
+    );
+
+    const studentSummaries = await database.getClassroomSummariesByStudent(
+      studentEmail
+    );
+    expect(studentSummaries.map((summary) => summary.classroomId)).toContain(
+      classroom.classroomId
+    );
+
+    const detailed = await database.getClassroomById(classroom.classroomId);
+    expect(detailed?.students.has(studentEmail)).toBe(true);
+
+    const updated = await database.updateClassroom({
+      classroomId: classroom.classroomId,
+      className: "Algebra II",
+    });
+    expect(updated?.className).toBe("Algebra II");
+
+    expect(await database.deleteClassroom(classroom.classroomId)).toBe(true);
+    expect(await database.getClassroomById(classroom.classroomId)).toBeNull();
   });
 });
 

--- a/server/tests/integration/classroom.routes.test.ts
+++ b/server/tests/integration/classroom.routes.test.ts
@@ -1,0 +1,303 @@
+import express from "express";
+import request from "supertest";
+import createClassroomRouter from "@/routes/classroom";
+import { DatabaseClassroom } from "@/database";
+
+describe("classroom router", () => {
+  const teacherEmail = "teacher@example.com";
+  const studentEmail = "student@example.com";
+
+  let app: express.Express;
+  let database: {
+    getClassroomSummariesByTeacher: jest.Mock;
+    getClassroomSummariesByStudent: jest.Mock;
+    getClassroomById: jest.Mock;
+    createClassroom: jest.Mock;
+    updateClassroom: jest.Mock;
+    deleteClassroom: jest.Mock;
+  };
+
+  const baseClassroom = (): DatabaseClassroom => ({
+    classroomId: "class-1",
+    className: "Algebra",
+    subject: "Math",
+    teacher: teacherEmail,
+    students: new Set([studentEmail]),
+    assignments: new Set(["assign-1"]),
+  });
+
+  beforeEach(() => {
+    database = {
+      getClassroomSummariesByTeacher: jest.fn(),
+      getClassroomSummariesByStudent: jest.fn(),
+      getClassroomById: jest.fn(),
+      createClassroom: jest.fn(),
+      updateClassroom: jest.fn(),
+      deleteClassroom: jest.fn(),
+    };
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      const role = req.header("x-user-role");
+      const email = req.header("x-user-email") ?? teacherEmail;
+      (req as any).isAuthenticated = () => Boolean(role);
+      if (role) {
+        (req as any).user = { email, role };
+      }
+      next();
+    });
+    app.use("/classroom", createClassroomRouter(database as any));
+  });
+
+  it("returns full classroom summaries for teachers by default", async () => {
+    database.getClassroomSummariesByTeacher.mockResolvedValue([
+      {
+        classroomId: "class-1",
+        className: "Algebra",
+        subject: "Math",
+        teacher: teacherEmail,
+      },
+    ]);
+
+    const response = await request(app)
+      .get("/classroom")
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      classrooms: [
+        {
+          classroomId: "class-1",
+          className: "Algebra",
+          subject: "Math",
+          teacher: teacherEmail,
+        },
+      ],
+    });
+  });
+
+  it("returns classroom ids when teachers request ids shape", async () => {
+    database.getClassroomSummariesByTeacher.mockResolvedValue([
+      {
+        classroomId: "class-1",
+        className: "Algebra",
+        subject: "Math",
+        teacher: teacherEmail,
+      },
+    ]);
+
+    const response = await request(app)
+      .get("/classroom")
+      .query({ shape: "ids" })
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ classrooms: ["class-1"] });
+  });
+
+  it("lists classrooms for students with ids by default", async () => {
+    database.getClassroomSummariesByStudent.mockResolvedValue([
+      {
+        classroomId: "class-1",
+        className: "Algebra",
+        subject: "Math",
+        teacher: teacherEmail,
+      },
+    ]);
+
+    const response = await request(app)
+      .get("/classroom")
+      .set("x-user-role", "student")
+      .set("x-user-email", studentEmail);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ classrooms: ["class-1"] });
+  });
+
+  it("returns full classroom summaries for students when requested", async () => {
+    database.getClassroomSummariesByStudent.mockResolvedValue([
+      {
+        classroomId: "class-1",
+        className: "Algebra",
+        subject: "Math",
+        teacher: teacherEmail,
+      },
+    ]);
+
+    const response = await request(app)
+      .get("/classroom")
+      .query({ shape: "full" })
+      .set("x-user-role", "student")
+      .set("x-user-email", studentEmail);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      classrooms: [
+        {
+          classroomId: "class-1",
+          className: "Algebra",
+          subject: "Math",
+          teacher: teacherEmail,
+        },
+      ],
+    });
+  });
+
+  it("rejects invalid shape parameters", async () => {
+    const response = await request(app)
+      .get("/classroom")
+      .query({ shape: "invalid" })
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns detailed classroom data for teacher owners", async () => {
+    const classroom = baseClassroom();
+    database.getClassroomById.mockResolvedValue(classroom);
+
+    const response = await request(app)
+      .get("/classroom")
+      .query({ classroomId: classroom.classroomId })
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail);
+
+    expect(response.status).toBe(200);
+    expect(response.body.classroom.students).toEqual([studentEmail]);
+    expect(response.body.classroom.assignments).toEqual(["assign-1"]);
+  });
+
+  it("forbids teachers from accessing classrooms they do not own", async () => {
+    const classroom = baseClassroom();
+    classroom.teacher = "other@example.com";
+    database.getClassroomById.mockResolvedValue(classroom);
+
+    const response = await request(app)
+      .get("/classroom")
+      .query({ classroomId: classroom.classroomId })
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows students to access classrooms they belong to", async () => {
+    const classroom = baseClassroom();
+    database.getClassroomById.mockResolvedValue(classroom);
+
+    const response = await request(app)
+      .get("/classroom")
+      .query({ classroomId: classroom.classroomId })
+      .set("x-user-role", "student")
+      .set("x-user-email", studentEmail);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("forbids students who are not members", async () => {
+    const classroom = baseClassroom();
+    classroom.students = new Set(["someone@example.com"]);
+    database.getClassroomById.mockResolvedValue(classroom);
+
+    const response = await request(app)
+      .get("/classroom")
+      .query({ classroomId: classroom.classroomId })
+      .set("x-user-role", "student")
+      .set("x-user-email", studentEmail);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("validates student email format during creation", async () => {
+    const response = await request(app)
+      .post("/classroom/create")
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail)
+      .send({
+        className: "Algebra",
+        subject: "Math",
+        students: ["invalid-email"],
+      });
+
+    expect(response.status).toBe(400);
+    expect(database.createClassroom).not.toHaveBeenCalled();
+  });
+
+  it("creates classrooms for teachers", async () => {
+    const classroom = baseClassroom();
+    database.createClassroom.mockResolvedValue(classroom);
+
+    const response = await request(app)
+      .post("/classroom/create")
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail)
+      .send({
+        className: "Algebra",
+        subject: "Math",
+        students: [studentEmail, studentEmail],
+      });
+
+    expect(response.status).toBe(201);
+    expect(database.createClassroom).toHaveBeenCalledWith({
+      className: "Algebra",
+      subject: "Math",
+      students: [studentEmail],
+      teacher: teacherEmail,
+    });
+  });
+
+  it("requires ownership for updates", async () => {
+    const classroom = baseClassroom();
+    classroom.teacher = "other@example.com";
+    database.getClassroomById.mockResolvedValue(classroom);
+
+    const response = await request(app)
+      .patch("/classroom/update")
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail)
+      .send({ classroomId: classroom.classroomId, className: "New" });
+
+    expect(response.status).toBe(403);
+    expect(database.updateClassroom).not.toHaveBeenCalled();
+  });
+
+  it("updates classroom metadata for owners", async () => {
+    const classroom = baseClassroom();
+    database.getClassroomById.mockResolvedValueOnce(classroom);
+    database.updateClassroom.mockResolvedValue({
+      ...classroom,
+      className: "Updated",
+    });
+
+    const response = await request(app)
+      .patch("/classroom/update")
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail)
+      .send({ classroomId: classroom.classroomId, className: "Updated" });
+
+    expect(response.status).toBe(200);
+    expect(database.updateClassroom).toHaveBeenCalledWith({
+      classroomId: classroom.classroomId,
+      className: "Updated",
+      subject: undefined,
+    });
+  });
+
+  it("deletes classrooms for owners", async () => {
+    const classroom = baseClassroom();
+    database.getClassroomById.mockResolvedValue(classroom);
+    database.deleteClassroom.mockResolvedValue(true);
+
+    const response = await request(app)
+      .delete(`/classroom/${classroom.classroomId}`)
+      .set("x-user-role", "teacher")
+      .set("x-user-email", teacherEmail);
+
+    expect(response.status).toBe(204);
+    expect(database.deleteClassroom).toHaveBeenCalledWith(classroom.classroomId);
+  });
+});

--- a/server/tests/integration/database.integration.test.ts
+++ b/server/tests/integration/database.integration.test.ts
@@ -15,14 +15,26 @@ describe("Database integration with mocked query runner", () => {
   });
 
   describe("initialize", () => {
-    it("executes the users table creation statement", async () => {
+    it("executes the schema creation statements", async () => {
       queryRunner.query.mockResolvedValue({ rows: [] });
 
       await database.initialize();
 
-      expect(queryRunner.query).toHaveBeenCalledTimes(1);
-      const [sql] = queryRunner.query.mock.calls[0];
-      expect(sql).toContain("CREATE TABLE IF NOT EXISTS users");
+      expect(queryRunner.query).toHaveBeenCalledTimes(5);
+      const executedSql = queryRunner.query.mock.calls.map(([sql]) => sql);
+      expect(executedSql[0]).toContain("CREATE TABLE IF NOT EXISTS users");
+      expect(executedSql).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("CREATE TABLE IF NOT EXISTS classrooms"),
+          expect.stringContaining(
+            "CREATE TABLE IF NOT EXISTS classroom_students"
+          ),
+          expect.stringContaining("CREATE TABLE IF NOT EXISTS assignments"),
+          expect.stringContaining(
+            "CREATE TABLE IF NOT EXISTS classroom_assignments"
+          ),
+        ])
+      );
     });
 
     it("propagates errors from the query runner", async () => {
@@ -203,6 +215,255 @@ describe("Database integration with mocked query runner", () => {
         fullName: "Ada Lovelace",
         role: "student",
       });
+    });
+  });
+
+  describe("classroom operations", () => {
+    it("creates a classroom and deduplicates students", async () => {
+      const studentCalls: unknown[][] = [];
+      queryRunner.query.mockImplementation((sql: string, params?: unknown[]) => {
+        if (sql.includes("INSERT INTO classrooms")) {
+          return Promise.resolve({ rows: [] });
+        }
+
+        if (sql.includes("INSERT INTO classroom_students")) {
+          studentCalls.push(params ?? []);
+          return Promise.resolve({ rows: [] });
+        }
+
+        if (sql.includes("FROM classrooms") && sql.includes("WHERE classroom_id = $1")) {
+          return Promise.resolve({
+            rows: [
+              {
+                classroom_id: params?.[0],
+                class_name: "Algebra",
+                subject: "Math",
+                teacher_email: "teacher@example.com",
+              },
+            ],
+          });
+        }
+
+        if (sql.includes("FROM classroom_students")) {
+          return Promise.resolve({
+            rows: [{ student_email: "student@example.com" }],
+          });
+        }
+
+        if (sql.includes("FROM classroom_assignments")) {
+          return Promise.resolve({ rows: [] });
+        }
+
+        return Promise.resolve({ rows: [] });
+      });
+
+      const classroom = await database.createClassroom({
+        className: "Algebra",
+        subject: "Math",
+        students: ["student@example.com", "student@example.com"],
+        teacher: "teacher@example.com",
+      });
+
+      const insertCall = queryRunner.query.mock.calls.find(([sql]) =>
+        sql.includes("INSERT INTO classrooms")
+      );
+      expect(insertCall).toBeDefined();
+      expect(insertCall?.[1]).toEqual([
+        expect.any(String),
+        "Algebra",
+        "Math",
+        "teacher@example.com",
+      ]);
+      expect(studentCalls).toHaveLength(1);
+      expect(studentCalls[0][0]).toEqual(expect.any(String));
+      expect(studentCalls[0][1]).toBe("student@example.com");
+      expect(Array.from(classroom.students)).toEqual(["student@example.com"]);
+      expect(classroom.assignments.size).toBe(0);
+    });
+
+    it("retrieves classroom summaries for a teacher", async () => {
+      queryRunner.query.mockResolvedValue({
+        rows: [
+          {
+            classroom_id: "c-1",
+            class_name: "Algebra",
+            subject: "Math",
+            teacher_email: "teacher@example.com",
+          },
+        ],
+      });
+
+      const summaries = await database.getClassroomSummariesByTeacher(
+        "teacher@example.com"
+      );
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining("FROM classrooms"),
+        ["teacher@example.com"]
+      );
+      expect(summaries).toEqual([
+        {
+          classroomId: "c-1",
+          className: "Algebra",
+          subject: "Math",
+          teacher: "teacher@example.com",
+        },
+      ]);
+    });
+
+    it("retrieves classroom summaries for a student", async () => {
+      queryRunner.query.mockResolvedValue({
+        rows: [
+          {
+            classroom_id: "c-2",
+            class_name: "Physics",
+            subject: "Science",
+            teacher_email: "teacher@example.com",
+          },
+        ],
+      });
+
+      const summaries = await database.getClassroomSummariesByStudent(
+        "student@example.com"
+      );
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining("INNER JOIN classroom_students"),
+        ["student@example.com"]
+      );
+      expect(summaries).toEqual([
+        {
+          classroomId: "c-2",
+          className: "Physics",
+          subject: "Science",
+          teacher: "teacher@example.com",
+        },
+      ]);
+    });
+
+    it("returns null when classroom is missing", async () => {
+      queryRunner.query.mockResolvedValue({ rows: [] });
+
+      const classroom = await database.getClassroomById("missing");
+
+      expect(classroom).toBeNull();
+    });
+
+    it("maps classroom details with students and assignments", async () => {
+      queryRunner.query.mockImplementation((sql: string, params?: unknown[]) => {
+        if (sql.includes("FROM classrooms") && sql.includes("WHERE classroom_id = $1")) {
+          return Promise.resolve({
+            rows: [
+              {
+                classroom_id: params?.[0],
+                class_name: "History",
+                subject: "Social Studies",
+                teacher_email: "teacher@example.com",
+              },
+            ],
+          });
+        }
+
+        if (sql.includes("FROM classroom_students")) {
+          return Promise.resolve({
+            rows: [
+              { student_email: "student1@example.com" },
+              { student_email: "student2@example.com" },
+            ],
+          });
+        }
+
+        if (sql.includes("FROM classroom_assignments")) {
+          return Promise.resolve({
+            rows: [
+              { assignment_id: "a-1" },
+              { assignment_id: "a-2" },
+            ],
+          });
+        }
+
+        return Promise.resolve({ rows: [] });
+      });
+
+      const classroom = await database.getClassroomById("class-123");
+
+      expect(classroom).not.toBeNull();
+      expect(classroom?.className).toBe("History");
+      expect(Array.from(classroom!.students)).toEqual([
+        "student1@example.com",
+        "student2@example.com",
+      ]);
+      expect(Array.from(classroom!.assignments)).toEqual(["a-1", "a-2"]);
+    });
+
+    it("updates classroom metadata", async () => {
+      queryRunner.query.mockImplementation((sql: string) => {
+        if (sql.startsWith("UPDATE classrooms")) {
+          return Promise.resolve({ rows: [] });
+        }
+
+        if (sql.includes("FROM classrooms") && sql.includes("WHERE classroom_id = $1")) {
+          return Promise.resolve({
+            rows: [
+              {
+                classroom_id: "class-456",
+                class_name: "Updated Name",
+                subject: "Updated Subject",
+                teacher_email: "teacher@example.com",
+              },
+            ],
+          });
+        }
+
+        if (sql.includes("FROM classroom_students")) {
+          return Promise.resolve({ rows: [] });
+        }
+
+        if (sql.includes("FROM classroom_assignments")) {
+          return Promise.resolve({ rows: [] });
+        }
+
+        return Promise.resolve({ rows: [] });
+      });
+
+      const updated = await database.updateClassroom({
+        classroomId: "class-456",
+        className: "Updated Name",
+        subject: "Updated Subject",
+      });
+
+      const updateCall = queryRunner.query.mock.calls.find(([sql]) =>
+        sql.startsWith("UPDATE classrooms")
+      );
+      expect(updateCall).toBeDefined();
+      expect(updateCall?.[1]).toEqual([
+        "Updated Name",
+        "Updated Subject",
+        "class-456",
+      ]);
+      expect(updated?.className).toBe("Updated Name");
+    });
+
+    it("deletes a classroom", async () => {
+      queryRunner.query.mockResolvedValueOnce({
+        rows: [{ classroom_id: "class-789" }],
+      });
+
+      const deleted = await database.deleteClassroom("class-789");
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM classrooms"),
+        ["class-789"]
+      );
+      expect(deleted).toBe(true);
+    });
+
+    it("returns false when delete affects no rows", async () => {
+      queryRunner.query.mockResolvedValueOnce({ rows: [] });
+
+      const deleted = await database.deleteClassroom("missing");
+
+      expect(deleted).toBe(false);
     });
   });
 

--- a/server/tests/unit/classroom.utils.test.ts
+++ b/server/tests/unit/classroom.utils.test.ts
@@ -1,0 +1,36 @@
+import { isValidEmail, sanitizeStudentEmails } from "@/routes/classroom";
+
+describe("sanitizeStudentEmails", () => {
+  it("returns an empty array when value is nullish", () => {
+    expect(sanitizeStudentEmails(undefined)).toEqual([]);
+    expect(sanitizeStudentEmails(null)).toEqual([]);
+  });
+
+  it("deduplicates and trims valid string entries", () => {
+    const result = sanitizeStudentEmails([
+      " alice@example.com ",
+      "bob@example.com",
+      "alice@example.com",
+      123,
+      null,
+    ]);
+
+    expect(result).toEqual(["alice@example.com", "bob@example.com"]);
+  });
+
+  it("returns null for non-array inputs", () => {
+    expect(sanitizeStudentEmails("not-an-array")).toBeNull();
+  });
+});
+
+describe("isValidEmail", () => {
+  it("accepts typical email addresses", () => {
+    expect(isValidEmail("user@example.com")).toBe(true);
+  });
+
+  it("rejects malformed inputs", () => {
+    expect(isValidEmail("missing-at-symbol")).toBe(false);
+    expect(isValidEmail("foo@bar")).toBe(false);
+    expect(isValidEmail("foo@bar.")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the database module with classroom tables, CRUD helpers, and in-memory fallbacks for tests
- add an authenticated /classroom router covering list/detail/create/update/delete flows with validation
- document the updated schema and add unit, integration, and e2e coverage for the classroom feature

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4df77be4c832bb43dcec0c7f6ad15